### PR TITLE
Do not complain about enum if parent type not resolved

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacProblemConverter.java
@@ -1005,7 +1005,16 @@ public class JavacProblemConverter {
 				}
 			}
 			case "compiler.err.non.sealed.sealed.or.final.expected" -> IProblem.SealedMissingClassModifier;
-			case "compiler.err.enum.annotation.must.be.enum.constant" -> IProblem.AnnotationValueMustBeAnEnumConstant;
+			case "compiler.err.enum.annotation.must.be.enum.constant" -> {
+				if (!(diagnostic instanceof JCDiagnostic jcDiagnostic)) {
+					yield -1;
+				}
+				DiagnosticPosition pos = jcDiagnostic.getDiagnosticPosition();
+				if (pos instanceof JCTree.JCFieldAccess fieldAccess && fieldAccess.type.isErroneous()) {
+					yield -1;
+				}
+				yield IProblem.AnnotationValueMustBeAnEnumConstant;
+			}
 			case "compiler.err.package.in.other.module" -> IProblem.ConflictingPackageFromOtherModules;
 			case "compiler.err.pkg.clashes.with.class.of.same.name" -> IProblem.PackageCollidesWithType;
 			case "compiler.err.module.decl.sb.in.module-info.java" -> {


### PR DESCRIPTION
In this case, where `MyEnum` exists but isn't imported:

```java
import dev.datho7561.Annotation;

@Annotation(MyEnum.VALUE)
public class MyClass {

}
```

javac reports an error on `MyEnum` and `VALUE`, whereas JDT just reports an error on `MyEnum`. This PR silences the error.

Should fix these tests:

```
org.eclipse.jdt.ui.tests.quickfix.QuickFixTest1d8.testIssue717_1
org.eclipse.jdt.ui.tests.quickfix.QuickFixTest1d8.testIssue717_2
```