### PR TITLE
Fix NPE in getExportedTo when target modules are null

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacModuleBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacModuleBinding.java
@@ -194,7 +194,11 @@ public abstract class JavacModuleBinding implements IModuleBinding {
 			JavacPackageBinding tmp = this.resolver.bindings.getPackageBinding(arr[i].packge);
 			if( tmp.isUnnamed() == packageBinding.isUnnamed() &&
 					tmp.getName().equals(packageBinding.getName())) {
-				return arr[i].getTargetModules().stream().map(ModuleSymbol::toString).toArray(String[]::new);
+				var targets = arr[i].getTargetModules();
+	            if (targets == null) {
+	                return new String[0];
+	            }
+				return targets.stream().map(ModuleSymbol::toString).toArray(String[]::new);
 			}
 		}
 		return new String[0];


### PR DESCRIPTION
java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because the return value of "com.sun.tools.javac.code.Directive$ExportsDirective.getTargetModules()" is null
	at org.eclipse.jdt.internal.javac.dom.JavacModuleBinding.getExportedTo(JavacModuleBinding.java:198)
	at org.eclipse.jdt.core.dom.rewrite.ImportRewrite.getPackages(ImportRewrite.java:451)