### PR TITLE
Fixes #173 - Prevent NPE in JavacMethodBinding.computeUnresolvedJavaE…

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/dom/JavacMethodBinding.java
@@ -695,6 +695,9 @@ public abstract class JavacMethodBinding implements IMethodBinding {
 					}
 				}
 			}
+			if (paramBinding == null) {
+			   paramBinding = this.resolver.resolveWellKnownType("java.lang.Object");
+			}
 			res[i] = paramBinding;
 		}
 		return maybeTrimEnumConstructorArgs(res);


### PR DESCRIPTION
This PR fixes the secondary NPE mentioned in #173.
This change adds a guard while constructing the resolved parameter list: if a parameter type cannot be resolved (`resolveTypeName` returns null)

This PR only addresses the NPE and does not attempt to fix the underlying wrong-type resolution described in #173.