### PR TITLE
Automatically attempt rebasing tests in build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
 						extensions: [ cloneOption(shallow: true) ],
 						userRemoteConfigs: [[url: 'https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator.git']])
 					sh """#!/bin/bash -x
+						git pull --rebase https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator.git master
 						mkdir -p $WORKSPACE/tmp
 						
 						unset JAVA_TOOL_OPTIONS


### PR DESCRIPTION
This attempts to always rebase tests on top of latest upstream as part of running the build.
This should reduce the amount of cases where tests are not in sync with the main eclipse.jdt.javac repo or its dependencies.

See https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/issues/1896