### PR TITLE
Fix testUnimplementedMethods2

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/problem/JavacDiagnosticProblemConverter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/problem/JavacDiagnosticProblemConverter.java
@@ -115,9 +115,6 @@ public class JavacDiagnosticProblemConverter {
 		if (diagnostic instanceof JCDiagnostic jcDiagnostic && COMPILER_ERR_DOES_NOT_OVERRIDE_ABSTRACT.equals(jcDiagnostic.getCode())) {
 			return createDoesNotOverrideAbstractProblems(jcDiagnostic);
 		}
-		if (diagnostic instanceof JCDiagnostic jcDiagnostic && COMPILER_ERR_DOES_NOT_OVERRIDE_ABSTRACT.equals(jcDiagnostic.getCode())) {
-			return createDoesNotOverrideAbstractProblems(jcDiagnostic);
-		}
 		JCDiagnostic nestedDiagnostic = getDiagnosticArgumentByType(diagnostic, JCDiagnostic.class);
 		boolean useNestedDiagnostic = nestedDiagnostic != null
 			&& diagnostic.getCode().equals("compiler.err.invalid.permits.clause")


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdtls/eclipse.jdt.javac/issues/160

Fixes the following test cases:
* `testUnimplementedMethods2`
* `testUnimplementedMethods_bug122906`
* `testUnimplementedMethodsInEnumConstant2`
* `testUnimplementedMethodsWithTypeParameters`
* `testUnimplementedMethodsInEnum`

This should also fix `testUnimplementedMethodsInEnumConstant3`. However, the test case is still failing because ECJ reports only a single error `The enum constant A must implement the abstract method foo()`, whereas this PR reports two errors, `The enum constant A must implement the abstract method foo()` and `The enum constant A must implement the abstract method run()`.
Despite this difference, both implementations ultimately produce the same result when applying the quick fix. It correctly generates implementations for both missing methods:
```java
enum E implements Runnable {
  A {
	@Override
	public void run() {
		// TODO Auto-generated method stub
		
	}

	@Override
	boolean foo() {
		// TODO Auto-generated method stub
		return false;
	}
};
  abstract boolean foo();
}
```
The test currently expects one error/proposal though, so it fails with this PR. But conceptually, I think this PR's behavior is more accurate, because the the case does need to implement both `run()` and `foo()`, and generating two markers reflects that accurately ....
