### PR TITLE
Fix `testUnusedTypeParameter`: add implementation in `JavacCompilerTaskListener`

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompilationResult.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompilationResult.java
@@ -34,6 +34,7 @@ public class JavacCompilationResult extends CompilationResult {
 	private List<CategorizedProblem> unnecessaryCasts = null;
 	private List<CategorizedProblem> noEffectAssignments = null;
 	private List<CategorizedProblem> unclosedCloseables = null;
+	private List<CategorizedProblem> unusedTypeParameters = null;
 	private List<CategorizedProblem> accessRestrictionProblems = null;
 
 	public JavacCompilationResult(ICompilationUnit compilationUnit) {
@@ -106,6 +107,13 @@ public class JavacCompilationResult extends CompilationResult {
 			this.unclosedCloseables = new ArrayList<>();
 		}
 		this.unclosedCloseables.addAll(problems);
+	}
+
+	public void getUnusedTypeParameters(List<CategorizedProblem> problems) {
+		if (this.unusedTypeParameters == null) {
+			this.unusedTypeParameters = new ArrayList<>();
+		}
+		this.unusedTypeParameters.addAll(problems);
 	}
 
 	public void setAccessRestrictionProblems(List<CategorizedProblem> problems) {

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompilerTaskListener.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompilerTaskListener.java
@@ -285,6 +285,7 @@ public class JavacCompilerTaskListener implements TaskListener {
 			result.addUnnecessaryCasts(scanner.getUnnecessaryCasts(this.unusedProblemFactory));
 			result.addNoEffectAssignments(scanner.getNoEffectAssignments(this.unusedProblemFactory));
 			result.addUnclosedCloseables(scanner.getUnclosedCloseables(this.unusedProblemFactory));
+			result.addUnusedTypeParameters(scanner.getUnusedTypeParameters(this.unusedProblemFactory));
 			result.setAccessRestrictionProblems(accessRestrictionScanner.getAccessRestrictionProblems());
 		}
 	}


### PR DESCRIPTION
Complementary to https://github.com/eclipse-jdtls/eclipse.jdt.javac/pull/190
I realized I missed adding the implementation on the `JavacCompilerTaskListener` side

Fixes https://github.com/eclipse-jdtls/eclipse.jdt.javac/issues/162