### PR TITLE
Report warnings/errors only when their corresponding compiler option is enabled

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompilationResult.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompilationResult.java
@@ -30,6 +30,7 @@ public class JavacCompilationResult extends CompilationResult {
 	private Set<String> javacRootReferences = new TreeSet<>();
 	private boolean isMigrated = false;
 	private List<CategorizedProblem> unusedMembers = null;
+	private List<CategorizedProblem> unusedLocalVariables = null;
 	private List<CategorizedProblem> unusedImports = null;
 	private List<CategorizedProblem> unnecessaryCasts = null;
 	private List<CategorizedProblem> noEffectAssignments = null;
@@ -92,6 +93,13 @@ public class JavacCompilationResult extends CompilationResult {
 		this.unusedMembers.addAll(problems);
 	}
 
+	public void addUnusedLocalVariables(List<CategorizedProblem> problems) {
+		if (this.unusedLocalVariables == null) {
+			this.unusedLocalVariables = new ArrayList<>();
+		}
+		this.unusedLocalVariables.addAll(problems);
+	}
+
 	public void addUnnecessaryCasts(List<CategorizedProblem> problems) {
 		if (this.unnecessaryCasts == null) {
 			this.unnecessaryCasts = new ArrayList<>();
@@ -143,6 +151,7 @@ public class JavacCompilationResult extends CompilationResult {
 
 	public List<CategorizedProblem> getAdditionalProblems() {
 		if (this.unusedMembers == null
+				&& this.unusedLocalVariables == null
 				&& this.unusedImports == null
 				&& this.unnecessaryCasts == null
 				&& this.noEffectAssignments == null
@@ -160,6 +169,9 @@ public class JavacCompilationResult extends CompilationResult {
 		}
 		if (this.unusedMembers != null) {
 			problems.addAll(this.unusedMembers);
+		}
+		if (this.unusedLocalVariables != null) {
+			problems.addAll(this.unusedLocalVariables);
 		}
 		if (this.unnecessaryCasts != null) {
 			problems.addAll(this.unnecessaryCasts);

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompilerTaskListener.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacCompilerTaskListener.java
@@ -55,11 +55,13 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ArrayType;
 import com.sun.tools.javac.code.Type.MethodType;
+import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCIdent;
 import com.sun.tools.javac.tree.JCTree.JCModuleDecl;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Options;
 
 public class JavacCompilerTaskListener implements TaskListener {
 	private Map<ICompilationUnit, JavacCompilationResult> results = new HashMap<>();
@@ -128,165 +130,177 @@ public class JavacCompilerTaskListener implements TaskListener {
 			final Map<Symbol, ClassFile> visitedClasses = new HashMap<Symbol, ClassFile>();
 			final Set<ClassSymbol> hierarchyRecorded = new HashSet<>();
 			final TypeElement currentTopLevelType = e.getTypeElement();
-			UnusedTreeScanner<Void, Void> scanner = new UnusedTreeScanner<>() {
-
-				@Override
-				public Void visitModule(com.sun.source.tree.ModuleTree node, Void p) {
-					if (node instanceof JCModuleDecl moduleDecl) {
-						IContainer expectedOutputDir = computeOutputDirectory(cu);
-						ClassFile currentClass = new JavacClassFile(moduleDecl, expectedOutputDir, tempDir);
-						result.record(MODULE_INFO_NAME, currentClass);
-					}
-					return super.visitModule(node, p);
-				}
-
-				@Override
-				public Void visitClass(ClassTree node, Void p) {
-					if (node instanceof JCClassDecl classDecl) {
-						/**
-						 * If a Java file contains multiple top-level types, it will
-						 * trigger multiple ANALYZE taskEvents for the same compilation
-						 * unit. Each ANALYZE taskEvent corresponds to the completion
-						 * of analysis for a single top-level type. Therefore, in the
-						 * ANALYZE task event listener, we only visit the class and nested
-						 * classes that belong to the currently analyzed top-level type.
-						 */
-						if (Objects.equals(currentTopLevelType, classDecl.sym)
-							|| !(classDecl.sym.owner instanceof PackageSymbol)) {
-							String fullName = classDecl.sym.flatName().toString();
-							String compoundName = fullName.replace('.', '/');
-							Symbol enclosingClassSymbol = this.getEnclosingClass(classDecl.sym);
-							ClassFile enclosingClassFile = enclosingClassSymbol == null ? null : visitedClasses.get(enclosingClassSymbol);
-							IContainer expectedOutputDir = computeOutputDirectory(cu);
-							ClassFile currentClass = new JavacClassFile(fullName, enclosingClassFile, expectedOutputDir, tempDir);
-							visitedClasses.put(classDecl.sym, currentClass);
-							result.record(compoundName.toCharArray(), currentClass);
-							recordTypeHierarchy(classDecl.sym);
-						} else {
-							return null; // Skip if it does not belong to the currently analyzed top-level type.
-						}
-					}
-
-					return super.visitClass(node, p);
-				}
-
-				@Override
-				public Void visitIdentifier(IdentifierTree node, Void p) {
-					if (node instanceof JCIdent id
-							&& id.sym instanceof TypeSymbol typeSymbol) {
-						String qualifiedName = typeSymbol.getQualifiedName().toString();
-						recordQualifiedReference(qualifiedName, false);
-					}
-					return super.visitIdentifier(node, p);
-				}
-
-				@Override
-				public Void visitMemberSelect(MemberSelectTree node, Void p) {
-					if (node instanceof JCFieldAccess field) {
-						if (field.sym != null &&
-							!(field.type instanceof MethodType || "<any?>".equals(field.type.toString()))) {
-							recordQualifiedReference(node.toString(), false);
-							if (field.sym instanceof VarSymbol) {
-								TypeSymbol elementSymbol = field.type.tsym;
-								if (field.type instanceof ArrayType arrayType) {
-									elementSymbol = getElementType(arrayType);
-								}
-								if (elementSymbol instanceof ClassSymbol classSymbol) {
-									recordQualifiedReference(classSymbol.className(), true);
-								}
-							}
-						}
-					}
-					return super.visitMemberSelect(node, p);
-				}
-
-				private Symbol getEnclosingClass(Symbol symbol) {
-					while (symbol != null) {
-						if (symbol.owner instanceof ClassSymbol) {
-							return symbol.owner;
-						} else if (symbol.owner instanceof PackageSymbol) {
-							return null;
-						}
-
-						symbol = symbol.owner;
-					}
-
-					return null;
-				}
-
-				private TypeSymbol getElementType(ArrayType arrayType) {
-					if (arrayType.elemtype instanceof ArrayType subArrayType) {
-						return getElementType(subArrayType);
-					}
-
-					return arrayType.elemtype.tsym;
-				}
-
-				private void recordQualifiedReference(String qualifiedName, boolean recursive) {
-					if (PRIMITIVE_TYPES.contains(qualifiedName)) {
-						return;
-					}
-
-					String[] nameParts = qualifiedName.split("\\.");
-					int length = nameParts.length;
-					if (length == 1) {
-						result.addRootReference(nameParts[0]);
-						result.addSimpleNameReference(nameParts[0]);
-						return;
-					}
-
-					if (!recursive) {
-						result.addRootReference(nameParts[0]);
-						result.addSimpleNameReference(nameParts[length - 1]);
-						result.addQualifiedReference(nameParts);
-					} else {
-						result.addRootReference(nameParts[0]);
-						while (result.addQualifiedReference(Arrays.copyOfRange(nameParts, 0, length))) {
-							if (length == 2) {
-								result.addSimpleNameReference(nameParts[0]);
-								result.addSimpleNameReference(nameParts[1]);
-								return;
-							}
-
-							length--;
-							result.addSimpleNameReference(nameParts[length]);
-						}
-					}
-				}
-
-				private void recordTypeHierarchy(ClassSymbol classSymbol) {
-					if (hierarchyRecorded.contains(classSymbol)) {
-						return;
-					}
-
-					hierarchyRecorded.add(classSymbol);
-					Type superClass = classSymbol.getSuperclass();
-					if (superClass.tsym instanceof ClassSymbol superClassType) {
-						recordQualifiedReference(superClassType.className(), true);
-						recordTypeHierarchy(superClassType);
-					}
-
-					for (Type superInterface : classSymbol.getInterfaces()) {
-						if (superInterface.tsym instanceof ClassSymbol superInterfaceType) {
-							recordQualifiedReference(superInterfaceType.className(), true);
-							recordTypeHierarchy(superInterfaceType);
-						}
-					}
-				}
-			};
-
 			final CompilationUnitTree unit = e.getCompilationUnit();
-			try {
-				scanner.scan(unit, null);
-			} catch (Exception ex) {
-				ILog.get().error("Internal error when visiting the AST Tree. " + ex.getMessage(), ex);
-			}
 
-			final var accessRestrictionScanner = new AccessRestrictionTreeScanner(javacCompiler.lookupEnvironment.nameEnvironment, this.problemFactory, this.javacCompiler.options);
-			accessRestrictionScanner.scan(unit, null);
-
+			boolean getUnusedPrivateMembers = this.javacCompiler.options.getSeverity(CompilerOptions.UnusedPrivateMember) != ProblemSeverities.Ignore;
+			boolean getUnusedLocalVariables = this.javacCompiler.options.getSeverity(CompilerOptions.UnusedLocalVariable) != ProblemSeverities.Ignore;
+			boolean getUnusedImports = this.javacCompiler.options.getSeverity(CompilerOptions.UnusedImport) != ProblemSeverities.Ignore;
+			boolean getUnnecessaryCasts = this.javacCompiler.options.getSeverity(CompilerOptions.UnnecessaryTypeCheck) != ProblemSeverities.Ignore;
+			boolean getNoEffectAssignments = this.javacCompiler.options.getSeverity(CompilerOptions.NoEffectAssignment) != ProblemSeverities.Ignore;
+			boolean getUnclosedCloseables = this.javacCompiler.options.getSeverity(CompilerOptions.UnclosedCloseable) != ProblemSeverities.Ignore;
+			boolean getUnusedTypeParameters = this.javacCompiler.options.getSeverity(CompilerOptions.UnusedTypeParameter) != ProblemSeverities.Ignore;
+			boolean getAccessRestrictions = Options.instance(context).get(Option.XLINT_CUSTOM).contains("all");
 			boolean getIndirectStaticAccessProblems = this.javacCompiler.options.getSeverity(CompilerOptions.IndirectStaticAccess) != ProblemSeverities.Ignore;
 			boolean getUnqualifiedFieldAccessProblems = this.javacCompiler.options.getSeverity(CompilerOptions.UnqualifiedFieldAccess) != ProblemSeverities.Ignore;
+
+			UnusedTreeScanner<Void, Void> unusedTreeScanner = null;
+			if (getUnusedPrivateMembers || getUnusedLocalVariables || getUnusedImports || getUnnecessaryCasts
+					|| getNoEffectAssignments || getUnclosedCloseables || getUnusedTypeParameters) {
+				unusedTreeScanner = new UnusedTreeScanner<>() {
+
+					@Override
+					public Void visitModule(com.sun.source.tree.ModuleTree node, Void p) {
+						if (node instanceof JCModuleDecl moduleDecl) {
+							IContainer expectedOutputDir = computeOutputDirectory(cu);
+							ClassFile currentClass = new JavacClassFile(moduleDecl, expectedOutputDir, tempDir);
+							result.record(MODULE_INFO_NAME, currentClass);
+						}
+						return super.visitModule(node, p);
+					}
+
+					@Override
+					public Void visitClass(ClassTree node, Void p) {
+						if (node instanceof JCClassDecl classDecl) {
+							/**
+							 * If a Java file contains multiple top-level types, it will
+							 * trigger multiple ANALYZE taskEvents for the same compilation
+							 * unit. Each ANALYZE taskEvent corresponds to the completion
+							 * of analysis for a single top-level type. Therefore, in the
+							 * ANALYZE task event listener, we only visit the class and nested
+							 * classes that belong to the currently analyzed top-level type.
+							 */
+							if (Objects.equals(currentTopLevelType, classDecl.sym)
+								|| !(classDecl.sym.owner instanceof PackageSymbol)) {
+								String fullName = classDecl.sym.flatName().toString();
+								String compoundName = fullName.replace('.', '/');
+								Symbol enclosingClassSymbol = this.getEnclosingClass(classDecl.sym);
+								ClassFile enclosingClassFile = enclosingClassSymbol == null ? null : visitedClasses.get(enclosingClassSymbol);
+								IContainer expectedOutputDir = computeOutputDirectory(cu);
+								ClassFile currentClass = new JavacClassFile(fullName, enclosingClassFile, expectedOutputDir, tempDir);
+								visitedClasses.put(classDecl.sym, currentClass);
+								result.record(compoundName.toCharArray(), currentClass);
+								recordTypeHierarchy(classDecl.sym);
+							} else {
+								return null; // Skip if it does not belong to the currently analyzed top-level type.
+							}
+						}
+
+						return super.visitClass(node, p);
+					}
+
+					@Override
+					public Void visitIdentifier(IdentifierTree node, Void p) {
+						if (node instanceof JCIdent id
+								&& id.sym instanceof TypeSymbol typeSymbol) {
+							String qualifiedName = typeSymbol.getQualifiedName().toString();
+							recordQualifiedReference(qualifiedName, false);
+						}
+						return super.visitIdentifier(node, p);
+					}
+
+					@Override
+					public Void visitMemberSelect(MemberSelectTree node, Void p) {
+						if (node instanceof JCFieldAccess field) {
+							if (field.sym != null &&
+								!(field.type instanceof MethodType || "<any?>".equals(field.type.toString()))) {
+								recordQualifiedReference(node.toString(), false);
+								if (field.sym instanceof VarSymbol) {
+									TypeSymbol elementSymbol = field.type.tsym;
+									if (field.type instanceof ArrayType arrayType) {
+										elementSymbol = getElementType(arrayType);
+									}
+									if (elementSymbol instanceof ClassSymbol classSymbol) {
+										recordQualifiedReference(classSymbol.className(), true);
+									}
+								}
+							}
+						}
+						return super.visitMemberSelect(node, p);
+					}
+
+					private Symbol getEnclosingClass(Symbol symbol) {
+						while (symbol != null) {
+							if (symbol.owner instanceof ClassSymbol) {
+								return symbol.owner;
+							} else if (symbol.owner instanceof PackageSymbol) {
+								return null;
+							}
+
+							symbol = symbol.owner;
+						}
+
+						return null;
+					}
+
+					private TypeSymbol getElementType(ArrayType arrayType) {
+						if (arrayType.elemtype instanceof ArrayType subArrayType) {
+							return getElementType(subArrayType);
+						}
+
+						return arrayType.elemtype.tsym;
+					}
+
+					private void recordQualifiedReference(String qualifiedName, boolean recursive) {
+						if (PRIMITIVE_TYPES.contains(qualifiedName)) {
+							return;
+						}
+
+						String[] nameParts = qualifiedName.split("\\.");
+						int length = nameParts.length;
+						if (length == 1) {
+							result.addRootReference(nameParts[0]);
+							result.addSimpleNameReference(nameParts[0]);
+							return;
+						}
+
+						if (!recursive) {
+							result.addRootReference(nameParts[0]);
+							result.addSimpleNameReference(nameParts[length - 1]);
+							result.addQualifiedReference(nameParts);
+						} else {
+							result.addRootReference(nameParts[0]);
+							while (result.addQualifiedReference(Arrays.copyOfRange(nameParts, 0, length))) {
+								if (length == 2) {
+									result.addSimpleNameReference(nameParts[0]);
+									result.addSimpleNameReference(nameParts[1]);
+									return;
+								}
+
+								length--;
+								result.addSimpleNameReference(nameParts[length]);
+							}
+						}
+					}
+
+					private void recordTypeHierarchy(ClassSymbol classSymbol) {
+						if (hierarchyRecorded.contains(classSymbol)) {
+							return;
+						}
+
+						hierarchyRecorded.add(classSymbol);
+						Type superClass = classSymbol.getSuperclass();
+						if (superClass.tsym instanceof ClassSymbol superClassType) {
+							recordQualifiedReference(superClassType.className(), true);
+							recordTypeHierarchy(superClassType);
+						}
+
+						for (Type superInterface : classSymbol.getInterfaces()) {
+							if (superInterface.tsym instanceof ClassSymbol superInterfaceType) {
+								recordQualifiedReference(superInterfaceType.className(), true);
+								recordTypeHierarchy(superInterfaceType);
+							}
+						}
+					}
+				};
+				unusedTreeScanner.scan(unit, null);
+			}
+
+			AccessRestrictionTreeScanner accessRestrictionScanner = null;
+			if (getAccessRestrictions) {
+				accessRestrictionScanner = new AccessRestrictionTreeScanner(javacCompiler.lookupEnvironment.nameEnvironment, this.problemFactory, this.javacCompiler.options);
+				accessRestrictionScanner.scan(unit, null);
+			}
+
 			CodeStyleTreeScanner codeStyleScanner = null;
 			if (getIndirectStaticAccessProblems || getUnqualifiedFieldAccessProblems) {
 				codeStyleScanner = new CodeStyleTreeScanner(this.context, this.problemFactory, this.javacCompiler.options) {
@@ -315,13 +329,32 @@ public class JavacCompilerTaskListener implements TaskListener {
 				codeStyleScanner.scan(unit, null);
 			}
 
-			result.addUnusedMembers(scanner.getUnusedPrivateMembers(this.unusedProblemFactory));
-			result.addUnusedImports(scanner.getUnusedImports(this.unusedProblemFactory));
-			result.addUnnecessaryCasts(scanner.getUnnecessaryCasts(this.unusedProblemFactory));
-			result.addNoEffectAssignments(scanner.getNoEffectAssignments(this.unusedProblemFactory));
-			result.addUnclosedCloseables(scanner.getUnclosedCloseables(this.unusedProblemFactory));
-			result.addUnusedTypeParameters(scanner.getUnusedTypeParameters(this.unusedProblemFactory));
-			result.addAccessRestrictionProblems(accessRestrictionScanner.getAccessRestrictionProblems());
+			if (unusedTreeScanner != null) {
+				if (getUnusedPrivateMembers) {
+					result.addUnusedMembers(unusedTreeScanner.getUnusedPrivateMembers(this.unusedProblemFactory));
+				}
+				if (getUnusedLocalVariables) {
+					result.addUnusedLocalVariables(unusedTreeScanner.getUnusedLocalVariables(this.unusedProblemFactory));
+				}
+				if (getUnusedImports) {
+					result.addUnusedImports(unusedTreeScanner.getUnusedImports(this.unusedProblemFactory));
+				}
+				if (getUnnecessaryCasts) {
+					result.addUnnecessaryCasts(unusedTreeScanner.getUnnecessaryCasts(this.unusedProblemFactory));
+				}
+				if (getNoEffectAssignments) {
+					result.addNoEffectAssignments(unusedTreeScanner.getNoEffectAssignments(this.unusedProblemFactory));
+				}
+				if (getUnclosedCloseables) {
+					result.addUnclosedCloseables(unusedTreeScanner.getUnclosedCloseables(this.unusedProblemFactory));
+				}
+				if (getUnusedTypeParameters) {
+					result.addUnusedTypeParameters(unusedTreeScanner.getUnusedTypeParameters(this.unusedProblemFactory));
+				}
+			}
+			if (accessRestrictionScanner != null) {
+				result.addAccessRestrictionProblems(accessRestrictionScanner.getAccessRestrictionProblems());
+			}
 			if (codeStyleScanner != null) {
 				if (getIndirectStaticAccessProblems) {
 					result.addIndirectStaticAccessProblems(codeStyleScanner.getIndirectStaticAccessProblems());

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacResolverTaskListener.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/JavacResolverTaskListener.java
@@ -152,6 +152,7 @@ public class JavacResolverTaskListener implements TaskListener {
 					.getSeverityString(CompilerOptions.IndirectStaticAccess).equals(CompilerOptions.IGNORE);
 		boolean unqualifiedFieldAccessIgnored = objectCompilerOptions
 					.getSeverityString(CompilerOptions.UnqualifiedFieldAccess).equals(CompilerOptions.IGNORE);
+
 		boolean getAccessRestrictions = Options.instance(context).get(Option.XLINT_CUSTOM).contains("all");
 		boolean getUnusedProblems = !unusedImportIgnored
 				|| !unusedPrivateMemberIgnored
@@ -167,8 +168,14 @@ public class JavacResolverTaskListener implements TaskListener {
 
 		// Add all problems related to unused elements to the dom
 		List<IProblem> accessRestrictions = getAccessRestrictions ? getAccessRestrictionProblems(e, dom) : new ArrayList<>();
-		List<IProblem> allUnused = getUnusedProblems ? getUnusedElementProblems(e, dom) : new ArrayList<>();
-		List<IProblem> codeStyles = getCodeStyleProblems ? getCodeStyleProblems(e, !indirectStaticAccessIgnored, !unqualifiedFieldAccessIgnored) : new ArrayList<>();
+		List<IProblem> allUnused = getUnusedProblems
+				? getUnusedElementProblems(e, dom,
+					!unusedPrivateMemberIgnored, !unusedLocalVariableIgnored, !unusedImportIgnored, !unnecessaryTypeCheckIgnored,
+					!noEffectAssignmentIgnored, !unclosedCloseableIgnored, !unusedTypeParameterIgnored)
+				: new ArrayList<>();
+		List<IProblem> codeStyles = getCodeStyleProblems
+				? getCodeStyleProblems(e, !indirectStaticAccessIgnored, !unqualifiedFieldAccessIgnored)
+				: new ArrayList<>();
 
 		List<IProblem> combined = new ArrayList<IProblem>();
 		combined.addAll(allUnused);
@@ -179,22 +186,22 @@ public class JavacResolverTaskListener implements TaskListener {
 	}
 
 	private List<IProblem> getAccessRestrictionProblems(TaskEvent e, CompilationUnit dom) {
-		if (Options.instance(context).get(Option.XLINT_CUSTOM).contains("all")) {
-			AccessRestrictionTreeScanner accessScanner = null;
-			if (javaProject instanceof JavaProject internalJavaProject) {
-				try {
-					INameEnvironment environment = new SearchableEnvironment(internalJavaProject,
-							(WorkingCopyOwner) null, false, JavaProject.NO_RELEASE);
-					accessScanner = new AccessRestrictionTreeScanner(environment, new DefaultProblemFactory(),
-							new CompilerOptions(compilerOptions));
-					accessScanner.scan(e.getCompilationUnit(), null);
-				} catch (JavaModelException javaModelException) {
-					// do nothing
-				}
+		AccessRestrictionTreeScanner accessScanner = null;
+		if (javaProject instanceof JavaProject internalJavaProject) {
+			try {
+				INameEnvironment environment = new SearchableEnvironment(internalJavaProject,
+						(WorkingCopyOwner) null, false, JavaProject.NO_RELEASE);
+				accessScanner = new AccessRestrictionTreeScanner(environment, new DefaultProblemFactory(),
+						new CompilerOptions(compilerOptions));
+				accessScanner.scan(e.getCompilationUnit(), null);
+			} catch (JavaModelException javaModelException) {
+				// do nothing
 			}
-			return new ArrayList<>(accessScanner.getAccessRestrictionProblems());
 		}
-		return new ArrayList<>();
+		if (accessScanner == null) {
+			return new ArrayList<>();
+		}
+		return new ArrayList<>(accessScanner.getAccessRestrictionProblems());
 	}
 
 	private List<IProblem> getCodeStyleProblems(TaskEvent e, boolean getIndirectStaticAccessProblems, boolean getUnqualifiedFieldAccessProblems) {
@@ -242,7 +249,9 @@ public class JavacResolverTaskListener implements TaskListener {
 		return allCodeStyleProblems;
 	}
 
-	private List<IProblem> getUnusedElementProblems(TaskEvent e, final CompilationUnit dom) {
+	private List<IProblem> getUnusedElementProblems(TaskEvent e, final CompilationUnit dom,
+			boolean getUnusedPrivateMembers, boolean getUnusedLocalVariables, boolean getUnusedImports, boolean getUnnecessaryCasts,
+			boolean getNoEffectAssignments, boolean getUnclosedCloseables, boolean getUnusedTypeParameters) {
 		final TypeElement currentTopLevelType = e.getTypeElement();
 		UnusedTreeScanner<Void, Void> scanner = new UnusedTreeScanner<>() {
 			@Override
@@ -275,42 +284,61 @@ public class JavacResolverTaskListener implements TaskListener {
 
 		List<IProblem> allUnusedProblems = new ArrayList<>();
 
-		List<CategorizedProblem> unusedProblems = scanner.getUnusedPrivateMembers(unusedProblemFactory);
-		if (unusedProblems != null && !unusedProblems.isEmpty()) {
-			allUnusedProblems.addAll(unusedProblems);
-		}
-
-		List<CategorizedProblem> unusedImports = scanner.getUnusedImports(unusedProblemFactory);
-		List<? extends Tree> topTypes = unit.getTypeDecls();
-		int typeCount = topTypes.size();
-		// Once all top level types of this Java file have been resolved,
-		// we can report the unused import to the DOM.
-		if (typeCount <= 1 && unusedImports != null) {
-			allUnusedProblems.addAll(unusedImports);
-		} else if (typeCount > 1 && topTypes.get(typeCount - 1) instanceof JCClassDecl lastType) {
-			if (Objects.equals(currentTopLevelType, lastType.sym)) {
-				allUnusedProblems.addAll(unusedImports);
+		if (getUnusedPrivateMembers) {
+			List<CategorizedProblem> unusedPrivateMembers = scanner.getUnusedPrivateMembers(unusedProblemFactory);
+			if (!unusedPrivateMembers.isEmpty()) {
+				allUnusedProblems.addAll(unusedPrivateMembers);
 			}
 		}
 
-		List<CategorizedProblem> unnecessaryCasts = scanner.getUnnecessaryCasts(unusedProblemFactory);
-		if (!unnecessaryCasts.isEmpty()) {
-			allUnusedProblems.addAll(unnecessaryCasts);
+		if (getUnusedLocalVariables) {
+			List<CategorizedProblem> unusedLocalVariables = scanner.getUnusedLocalVariables(unusedProblemFactory);
+			if (!unusedLocalVariables.isEmpty()) {
+				allUnusedProblems.addAll(unusedLocalVariables);
+			}
 		}
 
-		List<CategorizedProblem> noEffectAssignments = scanner.getNoEffectAssignments(unusedProblemFactory);
-		if (!noEffectAssignments.isEmpty()) {
-			allUnusedProblems.addAll(noEffectAssignments);
+		if (getUnusedImports) {
+			List<CategorizedProblem> unusedImports = scanner.getUnusedImports(unusedProblemFactory);
+			List<? extends Tree> topTypes = unit.getTypeDecls();
+			int typeCount = topTypes.size();
+			// Once all top level types of this Java file have been resolved,
+			// we can report the unused import to the DOM.
+			if (typeCount <= 1 && !unusedImports.isEmpty()) {
+				allUnusedProblems.addAll(unusedImports);
+			} else if (typeCount > 1 && topTypes.get(typeCount - 1) instanceof JCClassDecl lastType) {
+				if (Objects.equals(currentTopLevelType, lastType.sym)) {
+					allUnusedProblems.addAll(unusedImports);
+				}
+			}
 		}
 
-		List<CategorizedProblem> unclosedCloseables = scanner.getUnclosedCloseables(unusedProblemFactory);
-		if (!unclosedCloseables.isEmpty()) {
-			allUnusedProblems.addAll(unclosedCloseables);
+		if (getUnnecessaryCasts) {
+			List<CategorizedProblem> unnecessaryCasts = scanner.getUnnecessaryCasts(unusedProblemFactory);
+			if (!unnecessaryCasts.isEmpty()) {
+				allUnusedProblems.addAll(unnecessaryCasts);
+			}
 		}
 
-		List<CategorizedProblem> unusedTypeParameters = scanner.getUnusedTypeParameters(unusedProblemFactory);
-		if (!unusedTypeParameters.isEmpty()) {
-			allUnusedProblems.addAll(unusedTypeParameters);
+		if (getNoEffectAssignments) {
+			List<CategorizedProblem> noEffectAssignments = scanner.getNoEffectAssignments(unusedProblemFactory);
+			if (!noEffectAssignments.isEmpty()) {
+				allUnusedProblems.addAll(noEffectAssignments);
+			}
+		}
+
+		if (getUnclosedCloseables) {
+			List<CategorizedProblem> unclosedCloseables = scanner.getUnclosedCloseables(unusedProblemFactory);
+			if (!unclosedCloseables.isEmpty()) {
+				allUnusedProblems.addAll(unclosedCloseables);
+			}
+		}
+
+		if (getUnusedTypeParameters) {
+			List<CategorizedProblem> unusedTypeParameters = scanner.getUnusedTypeParameters(unusedProblemFactory);
+			if (!unusedTypeParameters.isEmpty()) {
+				allUnusedProblems.addAll(unusedTypeParameters);
+			}
 		}
 
 		return allUnusedProblems;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedTreeScanner.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/UnusedTreeScanner.java
@@ -576,30 +576,29 @@ public class UnusedTreeScanner<R, P> extends TreeScanner<R, P> {
 				} else if (decl instanceof JCMethodDecl methodDecl && !this.usedElements.contains(methodDecl.sym)) {
 					unusedPrivateMembers.add(decl);
 				} else if (decl instanceof JCVariableDecl variableDecl
-						&& !this.usedElements.contains(variableDecl.sym)) {
-					boolean suppressed = false;
-					for (JCAnnotation annot : variableDecl.mods.annotations) {
-						suppressed = isUnusedSuppressed(annot);
-						break;
-					}
-					VarSymbol varSymbol = variableDecl.sym;
-					ElementKind varKind = varSymbol == null ? null : varSymbol.getKind();
-					if (varKind == ElementKind.FIELD) {
-						if( varSymbol.owner instanceof ClassSymbol css) {
-							String name = variableDecl.name.toString();
-							if( css.getRecordComponents().map(x -> x.toString()).contains(name)) {
-								suppressed = true;
-							}
-						}
-					}
-
-					if (!suppressed) {
-						unusedPrivateMembers.add(decl);
-					}
+						&& !this.usedElements.contains(variableDecl.sym)
+						&& isUnusedPrivateField(variableDecl)
+						&& !isUnusedVariableSuppressed(variableDecl)) {
+					unusedPrivateMembers.add(decl);
 				}
 			}
 		}
 		return problemFactory.addUnusedPrivateMembers(unit, unusedPrivateMembers);
+	}
+
+	public List<CategorizedProblem> getUnusedLocalVariables(UnusedProblemFactory problemFactory) {
+		List<JCVariableDecl> unusedVariables = new ArrayList<>();
+		if (!classSuppressUnused && !methodSuppressUnused) {
+			for (Tree decl : this.privateDecls) {
+				if (decl instanceof JCVariableDecl variableDecl
+						&& !this.usedElements.contains(variableDecl.sym)
+						&& !isUnusedPrivateField(variableDecl)
+						&& !isUnusedVariableSuppressed(variableDecl)) {
+					unusedVariables.add(variableDecl);
+				}
+			}
+		}
+		return problemFactory.addUnusedLocalVariables(unit, unusedVariables);
 	}
 
 	public List<CategorizedProblem> getUnusedTypeParameters(UnusedProblemFactory problemFactory) {
@@ -634,6 +633,27 @@ public class UnusedTreeScanner<R, P> extends TreeScanner<R, P> {
 						}
 					}
 				}
+			}
+		}
+		return suppressed;
+	}
+
+	private boolean isUnusedPrivateField(JCVariableDecl variableDecl) {
+		VarSymbol varSymbol = variableDecl.sym;
+		return varSymbol != null && varSymbol.getKind() == ElementKind.FIELD;
+	}
+
+	private boolean isUnusedVariableSuppressed(JCVariableDecl variableDecl) {
+		boolean suppressed = false;
+		for (JCAnnotation annot : variableDecl.mods.annotations) {
+			suppressed = isUnusedSuppressed(annot);
+			break;
+		}
+		VarSymbol varSymbol = variableDecl.sym;
+		if (!suppressed && isUnusedPrivateField(variableDecl) && varSymbol.owner instanceof ClassSymbol css) {
+			String name = variableDecl.name.toString();
+			if (css.getRecordComponents().map(x -> x.toString()).contains(name)) {
+				suppressed = true;
 			}
 		}
 		return suppressed;

--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/problem/UnusedProblemFactory.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/problem/UnusedProblemFactory.java
@@ -66,7 +66,7 @@ public class UnusedProblemFactory {
 	public List<CategorizedProblem> addUnusedImports(CompilationUnitTree unit, Map<String, List<JCImport>> unusedImports) {
 		int severity = this.toSeverity(IProblem.UnusedImport);
 		if (severity == ProblemSeverities.Ignore || severity == ProblemSeverities.Optional) {
-			return null;
+			return Collections.emptyList();
 		}
 
 		Map<String, List<CategorizedProblem>> unusedWarning = new LinkedHashMap<>();
@@ -181,37 +181,67 @@ public class UnusedProblemFactory {
 						problemId, arguments, arguments,
 						severity, pos, endPos, line, column);
 			} else if (decl instanceof JCVariableDecl variableDecl) {
+				VarSymbol varSymbol = variableDecl.sym;
+				if (varSymbol == null || varSymbol.getKind() != ElementKind.FIELD) {
+					continue;
+				}
+
 				int pos = variableDecl.getPreferredPosition();
 				int endPos = pos + variableDecl.name.toString().length() - 1;
 				int line = (int) unit.getLineMap().getLineNumber(pos);
 				int column = (int) unit.getLineMap().getColumnNumber(pos);
-				int problemId = IProblem.LocalVariableIsNeverUsed;
+				String typeName = varSymbol.owner.name.toString();
 				String name = variableDecl.name.toString();
-				String[] arguments = new String[] { name };
-				VarSymbol varSymbol = variableDecl.sym;
-				ElementKind varKind = varSymbol == null ? null : varSymbol.getKind();
-				if (varKind == ElementKind.FIELD) {
-					problemId = IProblem.UnusedPrivateField;
-					String typeName = varSymbol.owner.name.toString();
-					arguments = new String[] {
-						typeName, name
-					};
-				} else if (varKind == ElementKind.PARAMETER) {
-					problemId = IProblem.ArgumentIsNeverUsed;
-				} else if (varKind == ElementKind.EXCEPTION_PARAMETER) {
-					problemId = IProblem.ExceptionParameterIsNeverUsed;
-				}
-
-				int severity = this.toSeverity(problemId);
+				String[] arguments = new String[] {
+					typeName, name
+				};
+				int severity = this.toSeverity(IProblem.UnusedPrivateField);
 				if (severity == ProblemSeverities.Ignore || severity == ProblemSeverities.Optional) {
 					continue;
 				}
 
 				problem = problemFactory.createProblem(fileName,
-						problemId, arguments, arguments,
+						IProblem.UnusedPrivateField, arguments, arguments,
 						severity, pos, endPos, line, column);
 			}
 
+			problems.add(problem);
+		}
+
+		return problems;
+	}
+
+	public List<CategorizedProblem> addUnusedLocalVariables(CompilationUnitTree unit, List<JCVariableDecl> unusedVariables) {
+		if (unit == null) {
+			return Collections.emptyList();
+		}
+
+		final char[] fileName = unit.getSourceFile().getName().toCharArray();
+		List<CategorizedProblem> problems = new ArrayList<>();
+		for (JCVariableDecl variableDecl : unusedVariables) {
+			int pos = variableDecl.getPreferredPosition();
+			int endPos = pos + variableDecl.name.toString().length() - 1;
+			int line = (int) unit.getLineMap().getLineNumber(pos);
+			int column = (int) unit.getLineMap().getColumnNumber(pos);
+			int problemId = IProblem.LocalVariableIsNeverUsed;
+			String name = variableDecl.name.toString();
+			String[] arguments = new String[] { name };
+			VarSymbol varSymbol = variableDecl.sym;
+			ElementKind varKind = varSymbol == null ? null : varSymbol.getKind();
+			if (varKind == ElementKind.PARAMETER) {
+				problemId = IProblem.ArgumentIsNeverUsed;
+			} else if (varKind == ElementKind.EXCEPTION_PARAMETER) {
+				problemId = IProblem.ExceptionParameterIsNeverUsed;
+			}
+
+			int severity = this.toSeverity(problemId);
+			if (severity == ProblemSeverities.Ignore || severity == ProblemSeverities.Optional) {
+				continue;
+			}
+
+			CategorizedProblem problem = problemFactory.createProblem(fileName,
+					problemId, arguments, arguments,
+					severity, pos, endPos, line, column);
 			problems.add(problem);
 		}
 


### PR DESCRIPTION
Fix reporting so warnings and errors are only added when their corresponding compiler option is enabled.

Currently, some warnings and errors are still reported even when their option is set to `ignore`. For example, tests that only enable `COMPILER_PB_UNUSED_PRIVATE_MEMBER` can also receive problems such as `NoEffectAssignment` or other members of the unused-problem family, even though those options are disabled. This happens because the current implementation only checks whether at least one related compiler option is not ignored, and then reports all problems in that group.

This PR separates and gates the added warnings and errors by their matching compiler options. This prevents extra problems from appearing when their warnings are disabled.