### PR TITLE
Remove LookupEnvironment from `resolve()`, instead find additional CUs to process from binding keys

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/core/dom/JavacCompilationUnitResolver.java
@@ -259,14 +259,47 @@ public class JavacCompilationUnitResolver implements ICompilationUnitResolver {
 	public void resolve(ICompilationUnit[] compilationUnits, String[] bindingKeys, ASTRequestor requestor, int apiLevel,
 			Map<String, String> compilerOptions, IJavaProject project, WorkingCopyOwner workingCopyOwner, int flags,
 			IProgressMonitor monitor) {
-		ICompilationUnit mockUnit = compilationUnits.length == 0 && bindingKeys.length > 0 ? createMockUnit(project, monitor) : null;
+		// source additional units from keys
+		List<ICompilationUnit> additionalUnits = new ArrayList<>();
+		for (int i = 0; i < bindingKeys.length; i++) {
+			CustomBindingKeyParser bkp = new CustomBindingKeyParser(bindingKeys[i]);
+			bkp.parse(true);
+			int lastDot = bkp.compoundName.lastIndexOf('.');
+			String packageName = lastDot == -1 ? "" : bkp.compoundName.substring(0, lastDot);
+			String simpleName = lastDot == -1 ? bkp.compoundName : bkp.compoundName.substring(lastDot + 1);
+			// find package
+			try {
+				for (IPackageFragmentRoot root : project.getPackageFragmentRoots()) {
+					if (root.getResource() instanceof IFolder) {
+						IPackageFragment pack = root.getPackageFragment(packageName);
+						ICompilationUnit a = pack.getCompilationUnit(simpleName + ".java");
+						if (a.exists()) {
+							additionalUnits.add(a);
+							break;
+						}
+					}
+				}
+			} catch (JavaModelException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+
+		ICompilationUnit mockUnit = compilationUnits.length == 0 && additionalUnits.size() == 0 && bindingKeys.length > 0 ? createMockUnit(project, monitor) : null;
 		if (mockUnit != null) {
 			// if we're looking for a key in a binary type and have no actual unit,
 			// create a mock to activate some compilation task, enable a bindingResolver
 			// and then allow looking up the binary types too
 			compilationUnits = new ICompilationUnit[] { mockUnit };
 		}
-		Map<ICompilationUnit, CompilationUnit> units = parse(compilationUnits, apiLevel, compilerOptions, true, flags, workingCopyOwner, monitor);
+
+		ICompilationUnit[] combinedUnits = new ICompilationUnit[compilationUnits.length + additionalUnits.size()];
+		System.arraycopy(compilationUnits, 0, combinedUnits, 0, compilationUnits.length);
+		for (int i = compilationUnits.length; i < combinedUnits.length; i++) {
+			combinedUnits[i] = additionalUnits.removeFirst();
+		}
+
+		Map<ICompilationUnit, CompilationUnit> units = parse(combinedUnits, apiLevel, compilerOptions, true, flags, workingCopyOwner, monitor);
 		if (requestor != null) {
 			final JavacBindingResolver[] bindingResolver = new JavacBindingResolver[1];
 			bindingResolver[0] = null;


### PR DESCRIPTION
Fixes #198