### PR TITLE
Fixes range for "Missing `@Override`" problem

### DIFF
--- a/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/problem/JavacProblemReporter.java
+++ b/org.eclipse.jdt.core.javac/src/org/eclipse/jdt/internal/javac/problem/JavacProblemReporter.java
@@ -69,7 +69,7 @@ public class JavacProblemReporter extends ProblemHandler {
 			0,
 			new String[] { binding.getName(), typesAsString(binding, true),
 					binding.getDeclaringClass().getName(), },
-			severity, method.getName().getStartPosition(), method.getStartPosition() + method.getLength() - 1);
+			severity, method.getName().getStartPosition(), method.getName().getStartPosition() + method.getName().getLength() - 1);
 	}
 
 	public void missingOverrideAnnotationForInterfaceMethodImplementation(MethodDeclaration method) {


### PR DESCRIPTION
The range includes just the method name now, which is what the range is when reported by ECJ.

eg. in the class `B`, just the text `foo` is marked with a warning instead of the entire method definition.

```java
public class MissingOverrides {
	static class A {
		void foo() {
			System.out.println("yippee!");
		}
	}
	static class B extends A {
		void foo() {
			System.out.println("awwww :(");
		}
	}
}
```

See https://github.com/eclipse-jdtls/eclipse.jdt.javac/issues/125#issuecomment-4135602190