### PR TITLE
Remove jdt-core-incubator p2 repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,12 +189,6 @@
 			<layout>p2</layout>
 			<url>https://download.eclipse.org/eclipse/updates/I-builds/</url>
 		</repository>
-		<!-- Forked JDT Core test bundles from incubator CI -->
-		<repository>
-			<id>jdt-core-fork-tests</id>
-			<layout>p2</layout>
-			<url>https://ci.eclipse.org/ls/job/jdt-core-incubator/job/dom-with-javac/lastSuccessfulBuild/artifact/repository/target/repository/</url>
-		</repository>
 	</repositories>
 
 	<pluginRepositories>


### PR DESCRIPTION
No longer accessible due to changes to Eclipse Jenkins that prevent unauthenticated access.