### PR TITLE
Properly escape variables in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,11 +93,11 @@ pipeline {
 			}
 			steps {
 				sshagent (credentials: ['projects-storage.eclipse.org-bot-ssh']) {
-					sh """#!/bin/bash -x
+					sh '''#!/bin/bash -x
 						# Clean previous builds
 						DOWNLOAD_AREA=/home/data/httpd/download.eclipse.org/jdtls/jdt-javac/snapshots
 
-						VERSION=`grep 'Bundle-Version: ' org.eclipse.jdt.core.javac/target/MANIFEST.MF | cut -d":" -f2 | tr -d '[:space:]'`
+						VERSION=`grep \'Bundle-Version: \' org.eclipse.jdt.core.javac/target/MANIFEST.MF | cut -d":" -f2 | tr -d \'[:space:]\'`
 						# Publish snapshot
 
 						P2_REPO=$DOWNLOAD_AREA/repository/${VERSION}
@@ -108,7 +108,7 @@ pipeline {
 						ssh genie.ls@projects-storage.eclipse.org rm -rf $LATEST_P2_REPO
 						ssh genie.ls@projects-storage.eclipse.org mkdir -p $LATEST_P2_REPO
 						scp -r repository/target/repository/** genie.ls@projects-storage.eclipse.org:$LATEST_P2_REPO
-"""
+'''
 				}
 			}
 		}


### PR DESCRIPTION
This will mean the declared bash variables get used instead of trying to substitute Jenkins variables into the string before running.